### PR TITLE
[Merged by Bors] - Make Terminal::print take a char

### DIFF
--- a/crates/terminal/src/lib.rs
+++ b/crates/terminal/src/lib.rs
@@ -5,7 +5,6 @@ use crossterm::{
 };
 use parking_lot::Mutex;
 use std::{
-    fmt::Display,
     io::{self, Write},
     sync::Arc,
     thread,
@@ -134,8 +133,8 @@ impl Terminal {
         *self.size.lock()
     }
 
-    pub fn print(&mut self, s: impl Display) -> anyhow::Result<()> {
-        self.stdout.write_all(format!("{}", s).as_bytes())?;
+    pub fn print(&mut self, c: char) -> anyhow::Result<()> {
+        self.stdout.write_all(c.to_string().as_bytes())?;
         Ok(())
     }
 


### PR DESCRIPTION
This makes implementing the screen buffer needed for #9 easier, as it’s guaranteed that each call to `Terminal::print` will only print another character.