### PR TITLE
[Merged by Bors] - Replace rand crate with oorandom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base-x"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
-
-[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,12 +112,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "discard"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
-
-[[package]]
 name = "etcetera"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,19 +155,19 @@ checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
+ "js-sys",
  "libc",
- "stdweb",
- "wasi",
+ "wasi 0.10.2+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -211,10 +199,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "0.4.7"
+name = "js-sys"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -274,7 +265,7 @@ name = "model"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "rand",
+ "rng",
  "serde",
  "terminal",
  "tincture",
@@ -286,7 +277,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac1378b66f7c93a1c0f8464a19bf47df8795083842e5090f4b7305973d5a22d0"
 dependencies = [
- "getrandom 0.2.0",
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -297,6 +288,12 @@ checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "parking_lot"
@@ -350,18 +347,12 @@ dependencies = [
  "anyhow",
  "etcetera",
  "model",
- "rand",
+ "rng",
  "serde",
  "structopt",
  "terminal",
  "toml",
 ]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro-error"
@@ -406,46 +397,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76330fb486679b4ace3670f117bbc9e16204005c4bde9c4bd372f45bed34f12"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8b34ba8cfb21243bd8df91854c830ff0d785fff2e82ebd4434c2644cb9ada18"
-dependencies = [
- "getrandom 0.2.0",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,40 +413,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+name = "rng"
+version = "0.1.0"
 dependencies = [
- "semver",
+ "getrandom 0.2.2",
+ "oorandom",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -516,23 +445,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "serde_json"
-version = "1.0.62"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "sha1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "signal-hook"
@@ -579,55 +491,6 @@ checksum = "7e529d73e80d64b5f2631f9035113347c578a1c9c7774b83a2b880788459ab36"
 dependencies = [
  "lock_api",
 ]
-
-[[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "strsim"
@@ -759,6 +622,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"

--- a/crates/model/src/direction.rs
+++ b/crates/model/src/direction.rs
@@ -1,7 +1,4 @@
-use rand::{
-    distributions::{Distribution, Standard},
-    Rng,
-};
+use rng::Rng;
 
 #[derive(Clone, Copy, PartialEq)]
 pub enum Direction {
@@ -12,9 +9,11 @@ pub enum Direction {
 }
 
 impl Direction {
-    pub fn maybe_turn(&mut self, turn_chance: f64) {
-        if Self::will_turn(turn_chance) {
-            *self = self.turn(TurnDirection::gen());
+    pub fn maybe_turn(&mut self, rng: &mut Rng, turn_chance: f32) {
+        let will_turn = rng.gen_bool(turn_chance);
+
+        if will_turn {
+            *self = self.turn(TurnDirection::gen(rng));
         }
     }
 
@@ -34,10 +33,6 @@ impl Direction {
             },
         }
     }
-
-    fn will_turn(turn_chance: f64) -> bool {
-        rand::thread_rng().gen_bool(turn_chance)
-    }
 }
 
 enum TurnDirection {
@@ -46,8 +41,8 @@ enum TurnDirection {
 }
 
 impl TurnDirection {
-    fn gen() -> Self {
-        if rand::thread_rng().gen_bool(0.5) {
+    fn gen(rng: &mut Rng) -> Self {
+        if rng.gen_bool(0.5) {
             Self::Left
         } else {
             Self::Right
@@ -55,9 +50,9 @@ impl TurnDirection {
     }
 }
 
-impl Distribution<Direction> for Standard {
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Direction {
-        match rng.gen_range(0..=3) {
+impl Direction {
+    pub(crate) fn gen(rng: &mut Rng) -> Self {
+        match rng.gen_range(0..4) {
             0 => Direction::Up,
             1 => Direction::Down,
             2 => Direction::Left,

--- a/crates/model/src/pipe/color.rs
+++ b/crates/model/src/pipe/color.rs
@@ -1,17 +1,21 @@
-use rand::Rng;
+use rng::Rng;
 use std::str::FromStr;
 use tincture::ColorSpace;
 
-pub(super) fn gen_random_color(color_mode: ColorMode, palette: Palette) -> Option<terminal::Color> {
+pub(super) fn gen_random_color(
+    rng: &mut Rng,
+    color_mode: ColorMode,
+    palette: Palette,
+) -> Option<terminal::Color> {
     match color_mode {
-        ColorMode::Ansi => Some(gen_random_ansi_color()),
-        ColorMode::Rgb => Some(gen_random_rgb_color(palette)),
+        ColorMode::Ansi => Some(gen_random_ansi_color(rng)),
+        ColorMode::Rgb => Some(gen_random_rgb_color(rng, palette)),
         ColorMode::None => None,
     }
 }
 
-fn gen_random_ansi_color() -> terminal::Color {
-    let num = rand::thread_rng().gen_range(0..=11);
+fn gen_random_ansi_color(rng: &mut Rng) -> terminal::Color {
+    let num = rng.gen_range(0..12);
 
     match num {
         0 => terminal::Color::Red,
@@ -30,8 +34,8 @@ fn gen_random_ansi_color() -> terminal::Color {
     }
 }
 
-fn gen_random_rgb_color(palette: Palette) -> terminal::Color {
-    let hue = rand::thread_rng().gen_range(0.0..=360.0);
+fn gen_random_rgb_color(rng: &mut Rng, palette: Palette) -> terminal::Color {
+    let hue = rng.gen_range_float(0.0..360.0);
     let oklch = tincture::Oklch {
         l: palette.get_lightness(),
         c: palette.get_chroma(),

--- a/crates/pipes-rs/Cargo.toml
+++ b/crates/pipes-rs/Cargo.toml
@@ -11,7 +11,7 @@ version = "1.2.0"
 anyhow = "1.0.37"
 etcetera = "0.3.2"
 model = {path = "../model"}
-rand = "0.8.0"
+rng = {path = "../rng"}
 serde = "1.0.118"
 structopt = "0.3.21"
 terminal = {path = "../terminal"}

--- a/crates/pipes-rs/src/config.rs
+++ b/crates/pipes-rs/src/config.rs
@@ -40,7 +40,7 @@ pub(crate) struct Config {
 
     /// chance of a pipe turning
     #[structopt(short, long)]
-    turn_chance: Option<f64>,
+    turn_chance: Option<f32>,
 }
 
 impl Config {
@@ -84,7 +84,7 @@ impl Config {
         self.num_pipes.unwrap_or(1)
     }
 
-    pub(crate) fn turn_chance(&self) -> f64 {
+    pub(crate) fn turn_chance(&self) -> f32 {
         self.turn_chance.unwrap_or(0.15)
     }
 

--- a/crates/rng/Cargo.toml
+++ b/crates/rng/Cargo.toml
@@ -2,14 +2,11 @@
 authors = ["CookieCoder15 <40507205+CookieCoder15@users.noreply.github.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
-name = "model"
+name = "rng"
 version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.37"
-rng = {path = "../rng"}
-serde = {version = "1.0.118", features = ["derive"]}
-terminal = {path = "../terminal"}
-tincture = "0.5.0"
+getrandom = "0.2.2"
+oorandom = "11.1.3"

--- a/crates/rng/src/lib.rs
+++ b/crates/rng/src/lib.rs
@@ -1,0 +1,67 @@
+use std::{fmt, ops::Range};
+
+pub struct Rng {
+    rand_32: oorandom::Rand32,
+    rand_64: oorandom::Rand64,
+}
+
+impl Rng {
+    pub fn new() -> Result<Self, Error> {
+        let (seed_64, seed_128) = gen_seed()?;
+
+        Ok(Self {
+            rand_32: oorandom::Rand32::new(seed_64),
+            rand_64: oorandom::Rand64::new(seed_128),
+        })
+    }
+
+    pub fn gen_range(&mut self, range: Range<u32>) -> u32 {
+        self.rand_32.rand_range(range)
+    }
+
+    pub fn gen_range_float(&mut self, range: Range<f32>) -> f32 {
+        self.rand_32.rand_float() * (range.end - range.start) + range.start
+    }
+
+    pub fn gen_range_16(&mut self, range: Range<u16>) -> u16 {
+        self.rand_32
+            .rand_range(range.start as u32..range.end as u32) as u16
+    }
+
+    pub fn gen_range_64(&mut self, range: Range<u64>) -> u64 {
+        self.rand_64.rand_range(range)
+    }
+
+    pub fn gen_range_size(&mut self, range: Range<usize>) -> usize {
+        self.rand_64
+            .rand_range(range.start as u64..range.end as u64) as usize
+    }
+
+    pub fn gen_bool(&mut self, probability: f32) -> bool {
+        assert!(probability >= 0.0);
+        assert!(probability <= 1.0);
+
+        self.rand_32.rand_float() < probability
+    }
+}
+
+fn gen_seed() -> Result<(u64, u128), Error> {
+    let mut seed_64 = [0; 8];
+    getrandom::getrandom(&mut seed_64).map_err(|_| Error)?;
+
+    let mut seed_128 = [0; 16];
+    getrandom::getrandom(&mut seed_128).map_err(|_| Error)?;
+
+    Ok((u64::from_le_bytes(seed_64), u128::from_le_bytes(seed_128)))
+}
+
+#[derive(Debug)]
+pub struct Error;
+
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "failed to get randomness from the OS")
+    }
+}


### PR DESCRIPTION
This should be ever-so-slightly faster as the application doesn’t have to repeatedly get a lock on the thread-local RNG like with `rand::thread_rng()`; instead, an `Rng` is passed around manually. Compilation is also faster.