### PR TITLE
[Merged by Bors] - Return an iterator instead of a Vec from PresetKindSet::chars

### DIFF
--- a/crates/model/src/pipe.rs
+++ b/crates/model/src/pipe.rs
@@ -258,11 +258,10 @@ impl FromStr for PresetKindSet {
 }
 
 impl PresetKindSet {
-    pub fn chars(&self) -> Vec<char> {
+    pub fn chars(&self) -> impl Iterator<Item = char> + '_ {
         self.0
             .iter()
             .map(|preset_kind| preset_kind.kind())
             .flat_map(|kind| kind.chars())
-            .collect()
     }
 }

--- a/crates/pipes-rs/src/main.rs
+++ b/crates/pipes-rs/src/main.rs
@@ -30,7 +30,7 @@ impl App {
     fn new() -> anyhow::Result<Self> {
         let config = read_config()?.combine(Config::from_args());
         let kinds = config.kinds();
-        let terminal = Terminal::new(&kinds.chars())?;
+        let terminal = Terminal::new(kinds.chars())?;
         let rng = Rng::new()?;
 
         Ok(Self {

--- a/crates/terminal/src/lib.rs
+++ b/crates/terminal/src/lib.rs
@@ -43,12 +43,8 @@ macro_rules! gen_terminal_method_bool {
 }
 
 impl Terminal {
-    pub fn new(chars: &[char]) -> anyhow::Result<Self> {
-        let max_char_width = chars
-            .iter()
-            .map(|c| c.width().unwrap() as u16)
-            .max()
-            .unwrap();
+    pub fn new(chars: impl Iterator<Item = char>) -> anyhow::Result<Self> {
+        let max_char_width = chars.map(|c| c.width().unwrap() as u16).max().unwrap();
 
         let size = {
             let (width, height) = terminal::size()?;


### PR DESCRIPTION
This avoids … wait for it … one allocation! An allocation that only occurs once on startup! Yeah!