### PR TITLE
[Merged by Bors] - Add spaces between dots pipes

### DIFF
--- a/crates/model/src/pipe.rs
+++ b/crates/model/src/pipe.rs
@@ -136,6 +136,7 @@ struct Kind {
     top_right: char,
     bottom_left: char,
     bottom_right: char,
+    width: KindWidth,
 }
 
 impl Kind {
@@ -153,6 +154,12 @@ impl Kind {
     }
 }
 
+#[derive(Clone, Copy)]
+enum KindWidth {
+    Auto,
+    Custom(usize),
+}
+
 impl PresetKind {
     const HEAVY: Kind = Kind {
         up: '┃',
@@ -163,6 +170,7 @@ impl PresetKind {
         top_right: '┓',
         bottom_left: '┗',
         bottom_right: '┛',
+        width: KindWidth::Auto,
     };
 
     const LIGHT: Kind = Kind {
@@ -174,6 +182,7 @@ impl PresetKind {
         top_right: '┐',
         bottom_left: '└',
         bottom_right: '┘',
+        width: KindWidth::Auto,
     };
 
     const CURVED: Kind = Kind {
@@ -185,6 +194,7 @@ impl PresetKind {
         top_right: '╮',
         bottom_left: '╰',
         bottom_right: '╯',
+        width: KindWidth::Auto,
     };
 
     const KNOBBY: Kind = Kind {
@@ -196,6 +206,7 @@ impl PresetKind {
         top_right: '┒',
         bottom_left: '┖',
         bottom_right: '┚',
+        width: KindWidth::Auto,
     };
 
     const EMOJI: Kind = Kind {
@@ -207,6 +218,7 @@ impl PresetKind {
         top_right: '👌',
         bottom_left: '👌',
         bottom_right: '👌',
+        width: KindWidth::Auto,
     };
 
     const OUTLINE: Kind = Kind {
@@ -218,6 +230,7 @@ impl PresetKind {
         top_right: '╗',
         bottom_left: '╚',
         bottom_right: '╝',
+        width: KindWidth::Auto,
     };
 
     const DOTS: Kind = Kind {
@@ -229,6 +242,7 @@ impl PresetKind {
         top_right: '•',
         bottom_left: '•',
         bottom_right: '•',
+        width: KindWidth::Custom(2),
     };
 
     fn kind(&self) -> Kind {
@@ -280,9 +294,17 @@ impl FromStr for PresetKindSet {
 
 impl PresetKindSet {
     pub fn chars(&self) -> impl Iterator<Item = char> + '_ {
-        self.0
-            .iter()
-            .map(|preset_kind| preset_kind.kind())
-            .flat_map(|kind| kind.chars())
+        self.kinds().flat_map(|kind| kind.chars())
+    }
+
+    pub fn custom_widths(&self) -> impl Iterator<Item = usize> + '_ {
+        self.kinds().filter_map(|kind| match kind.width {
+            KindWidth::Custom(n) => Some(n),
+            KindWidth::Auto => None,
+        })
+    }
+
+    fn kinds(&self) -> impl Iterator<Item = Kind> + '_ {
+        self.0.iter().map(|preset_kind| preset_kind.kind())
     }
 }

--- a/crates/pipes-rs/src/main.rs
+++ b/crates/pipes-rs/src/main.rs
@@ -33,7 +33,8 @@ impl App {
         let config = Config::read()?.combine(Config::from_args());
         config.validate()?;
         let kinds = config.kinds();
-        let terminal = Terminal::new(kinds.chars())?;
+        let largest_custom_width = kinds.custom_widths().max();
+        let terminal = Terminal::new(kinds.chars(), largest_custom_width)?;
         let rng = Rng::new()?;
 
         Ok(Self {

--- a/crates/terminal/src/lib.rs
+++ b/crates/terminal/src/lib.rs
@@ -21,8 +21,11 @@ pub struct Terminal {
 }
 
 impl Terminal {
-    pub fn new(chars: impl Iterator<Item = char>) -> anyhow::Result<Self> {
-        let max_char_width = chars.map(|c| c.width().unwrap() as u16).max().unwrap();
+    pub fn new(
+        chars: impl Iterator<Item = char>,
+        custom_width: Option<usize>,
+    ) -> anyhow::Result<Self> {
+        let max_char_width = Self::determine_max_char_width(chars, custom_width);
 
         let size = {
             let (width, height) = terminal::size()?;
@@ -68,6 +71,19 @@ impl Terminal {
             size,
             events_rx,
         })
+    }
+
+    fn determine_max_char_width(
+        chars: impl Iterator<Item = char>,
+        custom_width: Option<usize>,
+    ) -> u16 {
+        let max_char_width = chars.map(|c| c.width().unwrap() as u16).max().unwrap();
+
+        if let Some(custom_width) = custom_width {
+            max_char_width.max(custom_width as u16)
+        } else {
+            max_char_width
+        }
     }
 
     pub fn enable_bold(&mut self) -> anyhow::Result<()> {


### PR DESCRIPTION
Fixes #44.

Each dot now has a space between it and the next dot, making the spacing of dots more even.

Before:

https://user-images.githubusercontent.com/31783266/110316783-50c0e780-805f-11eb-8b42-66c055bd15a5.mov

After:

https://user-images.githubusercontent.com/31783266/110316667-24a56680-805f-11eb-92b7-c70e8d36e00c.mov

