### PR TITLE
[Merged by Bors] - Only keep two entries of pipe direction history

### DIFF
--- a/crates/model/src/pipe/history_keeper.rs
+++ b/crates/model/src/pipe/history_keeper.rs
@@ -1,0 +1,26 @@
+pub(super) struct HistoryKeeper<T: Copy> {
+    previous: Option<T>,
+    current: T,
+}
+
+impl<T: Copy> HistoryKeeper<T> {
+    pub(super) fn new(value: T) -> Self {
+        Self {
+            previous: None,
+            current: value,
+        }
+    }
+
+    pub(super) fn current(&self) -> T {
+        self.current
+    }
+
+    pub(super) fn previous(&self) -> Option<T> {
+        self.previous
+    }
+
+    pub(super) fn update(&mut self, mut f: impl FnMut(&mut T)) {
+        self.previous = Some(self.current);
+        f(&mut self.current);
+    }
+}


### PR DESCRIPTION
For some reason we were keeping an entire `Vec` of all the directions a pipe has had, when the only operations ever done on the `Vec` were:

- push a new element
- mutate the last element
- get the last element
- get the second-last element

This shows that only the current and previous direction are ever used. Thus, I have replaced the `Vec` with what is essentially a tuple of `(current, previous)`.

This change drastically reduces memory usage. Running in an 80×24 terminal window with `cargo r --release -- -p 929292 -d 0 -r 0`, memory usage varies between 90 and 105 MB. With this PR, memory usage stays still at exactly 57.2 MB. This makes sense, as before the time pipes would stay on the screen (something which varies randomly) impacted memory usage. Now, however, memory usage is constant.