### PR TITLE
[Merged by Bors] - Reduce memory usage by making Pipe smaller

### DIFF
--- a/crates/model/src/pipe.rs
+++ b/crates/model/src/pipe.rs
@@ -5,6 +5,7 @@ use crate::direction::Direction;
 use crate::position::InScreenBounds;
 use crate::position::Position;
 use rng::Rng;
+use std::num::NonZeroUsize;
 use std::{collections::HashSet, str::FromStr};
 
 pub struct Pipe {
@@ -157,7 +158,7 @@ impl Kind {
 #[derive(Clone, Copy)]
 enum KindWidth {
     Auto,
-    Custom(usize),
+    Custom(NonZeroUsize),
 }
 
 impl PresetKind {
@@ -242,7 +243,11 @@ impl PresetKind {
         top_right: '•',
         bottom_left: '•',
         bottom_right: '•',
-        width: KindWidth::Custom(2),
+
+        // ideally we would use NonZeroUsize::new(2).unwrap() here,
+        // but Option::unwrap in const contexts
+        // isn’t stable at the moment.
+        width: KindWidth::Custom(unsafe { NonZeroUsize::new_unchecked(2) }),
     };
 
     fn kind(&self) -> Kind {
@@ -297,7 +302,7 @@ impl PresetKindSet {
         self.kinds().flat_map(|kind| kind.chars())
     }
 
-    pub fn custom_widths(&self) -> impl Iterator<Item = usize> + '_ {
+    pub fn custom_widths(&self) -> impl Iterator<Item = NonZeroUsize> + '_ {
         self.kinds().filter_map(|kind| match kind.width {
             KindWidth::Custom(n) => Some(n),
             KindWidth::Auto => None,

--- a/crates/terminal/src/lib.rs
+++ b/crates/terminal/src/lib.rs
@@ -8,6 +8,7 @@ use crossterm::{
 use screen::Screen;
 use std::{
     io::{self, Write},
+    num::NonZeroUsize,
     thread,
 };
 use unicode_width::UnicodeWidthChar;
@@ -23,7 +24,7 @@ pub struct Terminal {
 impl Terminal {
     pub fn new(
         chars: impl Iterator<Item = char>,
-        custom_width: Option<usize>,
+        custom_width: Option<NonZeroUsize>,
     ) -> anyhow::Result<Self> {
         let max_char_width = Self::determine_max_char_width(chars, custom_width);
 
@@ -75,12 +76,12 @@ impl Terminal {
 
     fn determine_max_char_width(
         chars: impl Iterator<Item = char>,
-        custom_width: Option<usize>,
+        custom_width: Option<NonZeroUsize>,
     ) -> u16 {
         let max_char_width = chars.map(|c| c.width().unwrap() as u16).max().unwrap();
 
         if let Some(custom_width) = custom_width {
-            max_char_width.max(custom_width as u16)
+            max_char_width.max(custom_width.get() as u16)
         } else {
             max_char_width
         }


### PR DESCRIPTION
`Pipe` contains a `Kind` which contains a `KindWidth` which is defined as follows:

```rust
#[derive(Clone, Copy)]
enum KindWidth {
    Auto,
    Custom(usize),
}
```

As it stands, the size of `KindWidth` is 16: 8 bytes to represent the `usize`, plus another byte so we can tell whether the variant is `Auto` or `Custom`. Sizes have to be multiples of 8 bytes for alignment, though, so Rust adds another 7 bytes of padding for a total of 16 bytes.

If `KindWidth::Custom` is forbidden to be 0 (we can use `std::num::NonZeroUsize` for this), then Rust can use the ‘niche value optimisation’, where if the value is 0 it knows it must be `KindWidth::Auto`; otherwise, it knows the variant is `KindWidth::Custom`. This leads to `KindWidth`’s size being just 8 bytes, since it doesn’t take any extra data to store which variant it is in.

Therefore, this has reduced the size of `Pipe` from 80 bytes to 72 bytes.

It doesn’t make sense for the width of a pipe kind’s characters to be zero, so we’ve

- [made an illegal state unrepresentable](https://fsharpforfunandprofit.com/posts/designing-with-types-making-illegal-states-unrepresentable/). This prevents us from accidentally introducing a bug by making a pipe kind’s characters have zero width.
- reduced memory usage. Prior to this PR, memory usage when running using `cargo r --release -- -p 929292 -d 0 -r 0` was around 100MB, while with it memory usage is ~90MB.