### PR TITLE
[Merged by Bors] - Always inline Terminal::move_cursor_to

### DIFF
--- a/crates/terminal/src/lib.rs
+++ b/crates/terminal/src/lib.rs
@@ -131,6 +131,7 @@ impl Terminal {
         Ok(())
     }
 
+    #[inline(always)]
     pub fn move_cursor_to(&mut self, x: u16, y: u16) -> anyhow::Result<()> {
         let max_char_width = self.max_char_width;
         queue!(self.stdout, cursor::MoveTo(x * max_char_width, y))?;


### PR DESCRIPTION
This is the only `Terminal` function that wasn’t inlined automatically by LLVM, so I thought it would be good to force inlining it. All it does is forward to `core::fmt::write`, so I’d hazard a guess that this makes things faster, especially considering that it takes around 20% of pipes-rs’s runtime.