### PR TITLE
[Merged by Bors] - Lock stdout on application start

### DIFF
--- a/crates/terminal/src/lib.rs
+++ b/crates/terminal/src/lib.rs
@@ -13,16 +13,17 @@ use std::{
 };
 use unicode_width::UnicodeWidthChar;
 
-pub struct Terminal {
+pub struct Terminal<'a> {
     screen: Screen,
-    stdout: io::Stdout,
+    stdout: io::StdoutLock<'a>,
     max_char_width: u16,
     size: (u16, u16),
     events_rx: flume::Receiver<EventWithData>,
 }
 
-impl Terminal {
+impl<'a> Terminal<'a> {
     pub fn new(
+        stdout: io::StdoutLock<'a>,
         chars: impl Iterator<Item = char>,
         custom_width: Option<NonZeroUsize>,
     ) -> anyhow::Result<Self> {
@@ -67,7 +68,7 @@ impl Terminal {
 
         Ok(Self {
             screen,
-            stdout: io::stdout(),
+            stdout,
             max_char_width,
             size,
             events_rx,


### PR DESCRIPTION
Prior to this PR, 4.43% of runtime was spent waiting for a lock on stdout. This is pointless, as there is only ever one thread using stdout – pipes-rs’s main thread. Now, stdout is locked when pipes-rs starts, eliminating this time.