### PR TITLE
[Merged by Bors] - Use only one codegen unit in release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,5 @@
 members = ["crates/*"]
 
 [profile.release]
+codegen-units = 1
 lto = "fat"


### PR DESCRIPTION
This PR fixes #73.