### PR TITLE
[Merged by Bors] - Remove patch version specifications for dependencies past 1.0

### DIFF
--- a/crates/model/Cargo.toml
+++ b/crates/model/Cargo.toml
@@ -7,8 +7,8 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.37"
+anyhow = "1.0"
 rng = {path = "../rng"}
-serde = {version = "1.0.118", features = ["derive"]}
+serde = {version = "1.0", features = ["derive"]}
 terminal = {path = "../terminal"}
 tincture = "0.5.0"

--- a/crates/pipes-rs/Cargo.toml
+++ b/crates/pipes-rs/Cargo.toml
@@ -7,12 +7,12 @@ version = "1.4.5"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.37"
+anyhow = "1.0"
 etcetera = "0.3.2"
 mimalloc = {version = "0.1.25", default-features = false}
 model = {path = "../model"}
 rng = {path = "../rng"}
-serde = "1.0.118"
+serde = "1.0"
 structopt = "0.3.21"
 terminal = {path = "../terminal"}
 toml = "0.5.8"

--- a/crates/rng/Cargo.toml
+++ b/crates/rng/Cargo.toml
@@ -8,4 +8,4 @@ version = "0.1.0"
 
 [dependencies]
 getrandom = "0.2.2"
-oorandom = "11.1.3"
+oorandom = "11.1"

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.37"
+anyhow = "1.0"
 crossterm = "0.19.0"
 unicode-width = "0.1.8"
 


### PR DESCRIPTION
Patch versions for crates at or past 1.0 are unneeded, since we don’t depend on any specific bug fixes being present.