### PR TITLE
[Merged by Bors] - Use 0.0.0 for all subcrate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "model"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "rng",
@@ -644,7 +644,7 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "rng"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "getrandom",
  "oorandom",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "terminal"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "crossterm",

--- a/crates/model/Cargo.toml
+++ b/crates/model/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2018"
 license = "MIT OR Apache-2.0"
 name = "model"
-version = "0.1.0"
+version = "0.0.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rng/Cargo.toml
+++ b/crates/rng/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2018"
 license = "MIT OR Apache-2.0"
 name = "rng"
-version = "0.1.0"
+version = "0.0.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2018"
 license = "MIT OR Apache-2.0"
 name = "terminal"
-version = "0.1.0"
+version = "0.0.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Subcrates have no meaningful versions; using `version = "0.0.0"` helps express this.