### PR TITLE
[Merged by Bors] - Refactor to remove need for `Rand64`

### DIFF
--- a/crates/model/src/pipe/kind.rs
+++ b/crates/model/src/pipe/kind.rs
@@ -1,3 +1,4 @@
+use rng::Rng;
 use std::num::NonZeroUsize;
 use std::str::FromStr;
 
@@ -129,8 +130,9 @@ impl KindSet {
         Self(vec![kind])
     }
 
-    pub fn iter(&self) -> impl ExactSizeIterator<Item = Kind> + '_ {
-        self.0.iter().copied()
+    pub fn choose_random(&self, rng: &mut Rng) -> Kind {
+        let idx = rng.gen_range(0..self.0.len() as u32);
+        self.0[idx as usize]
     }
 
     pub fn chars(&self) -> impl Iterator<Item = char> + '_ {

--- a/crates/pipes-rs/src/lib.rs
+++ b/crates/pipes-rs/src/lib.rs
@@ -2,7 +2,7 @@ mod config;
 pub use config::Config;
 
 use model::{
-    pipe::{Kind, KindSet, Pipe},
+    pipe::{KindSet, Pipe},
     position::InScreenBounds,
 };
 use rng::Rng;
@@ -131,7 +131,7 @@ impl<B: Backend> App<B> {
     }
 
     fn create_pipe(&mut self) -> Pipe {
-        let kind = self.random_kind();
+        let kind = self.kinds.choose_random(&mut self.rng);
 
         Pipe::new(
             self.terminal.size(),
@@ -148,15 +148,6 @@ impl<B: Backend> App<B> {
             None => true,
         }
     }
-
-    fn random_kind(&mut self) -> Kind {
-        choose_random(self.kinds.iter(), &mut self.rng)
-    }
-}
-
-fn choose_random<T>(mut iter: impl ExactSizeIterator<Item = T>, rng: &mut Rng) -> T {
-    let index = rng.gen_range_size(0..iter.len());
-    iter.nth(index).unwrap()
 }
 
 #[must_use]

--- a/crates/rng/src/lib.rs
+++ b/crates/rng/src/lib.rs
@@ -1,17 +1,15 @@
-use std::{fmt, ops::Range};
+use std::ops::Range;
 
 pub struct Rng {
     rand_32: oorandom::Rand32,
-    rand_64: oorandom::Rand64,
 }
 
 impl Rng {
-    pub fn new() -> Result<Self, Error> {
-        let (seed_64, seed_128) = gen_seed()?;
+    pub fn new() -> Result<Self, getrandom::Error> {
+        let seed_64 = gen_seed()?;
 
         Ok(Self {
             rand_32: oorandom::Rand32::new(seed_64),
-            rand_64: oorandom::Rand64::new(seed_128),
         })
     }
 
@@ -28,15 +26,6 @@ impl Rng {
             .rand_range(range.start as u32..range.end as u32) as u16
     }
 
-    pub fn gen_range_64(&mut self, range: Range<u64>) -> u64 {
-        self.rand_64.rand_range(range)
-    }
-
-    pub fn gen_range_size(&mut self, range: Range<usize>) -> usize {
-        self.rand_64
-            .rand_range(range.start as u64..range.end as u64) as usize
-    }
-
     pub fn gen_bool(&mut self, probability: f32) -> bool {
         assert!(probability >= 0.0);
         assert!(probability <= 1.0);
@@ -45,23 +34,9 @@ impl Rng {
     }
 }
 
-fn gen_seed() -> Result<(u64, u128), Error> {
+fn gen_seed() -> Result<u64, getrandom::Error> {
     let mut seed_64 = [0; 8];
-    getrandom::getrandom(&mut seed_64).map_err(|_| Error)?;
+    getrandom::getrandom(&mut seed_64)?;
 
-    let mut seed_128 = [0; 16];
-    getrandom::getrandom(&mut seed_128).map_err(|_| Error)?;
-
-    Ok((u64::from_le_bytes(seed_64), u128::from_le_bytes(seed_128)))
-}
-
-#[derive(Debug)]
-pub struct Error;
-
-impl std::error::Error for Error {}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "failed to get randomness from the OS")
-    }
+    Ok(u64::from_le_bytes(seed_64))
 }


### PR DESCRIPTION
Now the one place where 64-bit random numbers were used just uses 32-bit random numbers and casts. This is possible since they were used for choosing a random pipe kind; although technically there could be up to `usize::MAX` kinds, practically this is not going to happen and thus 32 bits are sufficient.