### PR TITLE
[Merged by Bors] - Make formatting of imports consistent

### DIFF
--- a/crates/model/src/pipe.rs
+++ b/crates/model/src/pipe.rs
@@ -7,8 +7,7 @@ use history_keeper::HistoryKeeper;
 pub use kind::{Kind, KindSet};
 
 use crate::direction::Direction;
-use crate::position::InScreenBounds;
-use crate::position::Position;
+use crate::position::{InScreenBounds, Position};
 use rng::Rng;
 
 pub struct Pipe {

--- a/crates/model/src/pipe/color.rs
+++ b/crates/model/src/pipe/color.rs
@@ -1,5 +1,6 @@
 use rng::Rng;
-use std::{ops::Range, str::FromStr};
+use std::ops::Range;
+use std::str::FromStr;
 use tincture::ColorSpace;
 
 pub(super) fn gen_random_color(

--- a/crates/pipes-rs/src/config.rs
+++ b/crates/pipes-rs/src/config.rs
@@ -2,7 +2,9 @@ use anyhow::Context;
 use etcetera::app_strategy::{AppStrategy, AppStrategyArgs, Xdg};
 use model::pipe::{ColorMode, Kind, KindSet, Palette};
 use serde::{Deserialize, Serialize};
-use std::{fs, path::PathBuf, time::Duration};
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
 use structopt::clap::AppSettings;
 use structopt::StructOpt;
 

--- a/crates/pipes-rs/src/lib.rs
+++ b/crates/pipes-rs/src/lib.rs
@@ -1,10 +1,8 @@
 mod config;
 pub use config::Config;
 
-use model::{
-    pipe::{KindSet, Pipe},
-    position::InScreenBounds,
-};
+use model::pipe::{KindSet, Pipe};
+use model::position::InScreenBounds;
 use rng::Rng;
 use std::thread;
 use terminal::{Backend, Event, Terminal};

--- a/crates/terminal/src/lib.rs
+++ b/crates/terminal/src/lib.rs
@@ -5,13 +5,12 @@ mod void_backend;
 pub use stdout_backend::StdoutBackend;
 pub use void_backend::VoidBackend;
 
-use crossterm::{
-    cursor,
-    event::{Event as CrosstermEvent, KeyCode, KeyEvent, KeyModifiers},
-    queue, style, terminal,
-};
+use crossterm::event::{Event as CrosstermEvent, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::{cursor, queue, style, terminal};
 use screen::Screen;
-use std::{io::Write, num::NonZeroUsize, thread};
+use std::io::Write;
+use std::num::NonZeroUsize;
+use std::thread;
 use unicode_width::UnicodeWidthChar;
 
 pub struct Terminal<B: Backend> {


### PR DESCRIPTION
Unfortunately the `imports_granularity` option of rustfmt I used to automate this change [is unstable](https://github.com/rust-lang/rustfmt/issues/4991).