### PR TITLE
[Merged by Bors] - Don’t allocate new memory for `Screen` during resize

### DIFF
--- a/crates/terminal/src/lib.rs
+++ b/crates/terminal/src/lib.rs
@@ -184,7 +184,7 @@ impl Terminal {
 
     fn resize(&mut self, width: u16, height: u16) {
         self.size = (width, height);
-        self.screen = Screen::new(width as usize, height as usize);
+        self.screen.resize(width as usize, height as usize);
     }
 }
 

--- a/crates/terminal/src/screen.rs
+++ b/crates/terminal/src/screen.rs
@@ -15,6 +15,15 @@ impl Screen {
         }
     }
 
+    pub(crate) fn resize(&mut self, width: usize, height: usize) {
+        self.cells
+            .resize(width * height, Cell { is_covered: false });
+        self.cursor = (0, 0);
+        self.width = width;
+        self.height = height;
+        self.clear();
+    }
+
     pub(crate) fn move_cursor_to(&mut self, x: usize, y: usize) {
         assert!(x < self.width);
         assert!(y < self.height);


### PR DESCRIPTION
Instead of calling `Screen::new` (which allocates a new screen) and dropping the old one, let’s just reuse the existing `Screen`’s `Vec` and reset the state.